### PR TITLE
Code to checkpoint numpyro runs

### DIFF
--- a/bilby_numpyro/numpyro.py
+++ b/bilby_numpyro/numpyro.py
@@ -183,7 +183,7 @@ class NumPyro(Sampler):
 
     def _run_with_checkpointing(self, mcmc, sample_key):
 
-        checkpoint_file = self.outdir + "/numpyro_checkpoint.pkl"
+        checkpoint_file = f"{self.outdir}/numpyro_checkpoint.pkl"
 
         # first run
         if not os.path.isfile(checkpoint_file):

--- a/bilby_numpyro/numpyro.py
+++ b/bilby_numpyro/numpyro.py
@@ -201,7 +201,7 @@ class NumPyro(Sampler):
             checkpoint["log_likelihood"] = log_likelihood(
                 mcmc.sampler.model, mcmc.get_samples()
             )
-            checkpoint['new_key'] = new_key
+            checkpoint["new_key"] = new_key
 
             logger.info(
                 "checkpointing at "
@@ -218,7 +218,7 @@ class NumPyro(Sampler):
 
         while checkpoint["num_samples"] < self.kwargs["num_total_samples"]:
 
-            new_key, sample_key = jax.random.split(checkpoint['new_key'], 2)
+            new_key, sample_key = jax.random.split(checkpoint["new_key"], 2)
 
             # fix checkpoint state as post warmup state
             mcmc.post_warmup_state = checkpoint["state"]
@@ -243,8 +243,8 @@ class NumPyro(Sampler):
             checkpoint["num_samples"] = (
                 checkpoint["samples"][list(checkpoint["samples"].keys())[0]]
             ).size
-            checkpoint['new_key'] = new_key
-            
+            checkpoint["new_key"] = new_key
+
             logger.info(
                 "checkpointing at "
                 + str(checkpoint["num_samples"])

--- a/tests/test_bilby_integration.py
+++ b/tests/test_bilby_integration.py
@@ -43,5 +43,8 @@ def test_run_sampler(bilby_likelihood, bilby_priors, tmp_path, sampler_kwargs):
         priors=bilby_priors,
         sampler="numpyro",    # This should match the name of the sampler
         outdir=outdir,
+        num_samples=1000,
+        check_point=True,
+        n_check_point=200,
         **sampler_kwargs,
     )


### PR DESCRIPTION
Checkpointing can be enabled by passing `check_point=True`and `n_check_point`. The latter sets the periodic interval at which checkpointing happens. The state of the sampler and accepted samples are stored in a pickle file. Checkpointing relies on the `last_state` and `post_warmup_state` attributes of numpyro's samplers. 

 

